### PR TITLE
Refactoring and fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ pom.xml.asc
 /.nrepl-port
 .hgignore
 .hg/
+/bin/
+/.classpath
+/.project
+/.settings/

--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,6 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [net.mikera/core.matrix "0.36.1"]
                  [net.mikera/core.matrix.testing "0.0.4"]
-                 [org.nd4j/nd4j-jblas "0.0.3.5.5.6-SNAPSHOT"]
+                 [org.nd4j/nd4j-jblas "0.0.3.5.5.5"]
                  #_[org.nd4j/jcublas "6.5"]
                  #_[org.nd4j/nd4j-jcublas-6.5 "0.0.3.5.5.6-SNAPSHOT"]])

--- a/src/clj_nd4j/core.clj
+++ b/src/clj_nd4j/core.clj
@@ -108,11 +108,14 @@
      have the specified dimension."
     (aget (.shape m) (long dimension-number)))
 
+  ;; TODO: for some reason the [row] and [row,column] accessors trigger an ND4J bug?
   mp/PIndexedAccess
   (mp/get-1d [m row]
-    (.getDouble m (int row)))
+    (let [ixs (int-array [row])]
+      (.getDouble m ixs)))
   (mp/get-2d [m row column]
-    (.getDouble m (int row) (int column)))
+    (let [ixs (int-array [row column])]
+      (.getDouble m ixs)))
   (mp/get-nd [m indexes]
     (let [ixs (int-array indexes)]
       (.getDouble m ixs)))


### PR DESCRIPTION
Some changes to improve the implementation and improve core.matrix compliance. The tests still fail, but I think this is now down to a ND4J bug in array indexing. Demonstration of problem:

=> (def b (array :nd4j [[5 6 7]]))
# 'clj-nd4j.core/b

=> (mget b 0 0)
5.0
=> (mget b 0 1)
IllegalArgumentException Illegal index 3 derived from 1 with offset of 0 and stride of 3  org.nd4j.linalg.api.ndarray.BaseNDArray.linearIndex (BaseNDArray.java:2886)
